### PR TITLE
BUG: Superbuild linking ITKIO modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ ITKIOTransformBase
 ITKIOHDF5
 ITKIOTransformMatlab
 ITKIOTransformHDF5
+ITKIOLSM
+ITKIOStimulate
+ITKIOBioRad
+ITKIOMRC
+ITKIOGE
+MGHIO
 )
 
 include_directories( Common )


### PR DESCRIPTION
When superbuild is enabled. The same ITK modules are now required to link successfully some of the niral_utilities executables
